### PR TITLE
Add config option for retrogeneration, defaults to true as it's the value set by the repo owner

### DIFF
--- a/src/main/java/ruiseki/okprogressions/OKProgressions.java
+++ b/src/main/java/ruiseki/okprogressions/OKProgressions.java
@@ -64,7 +64,7 @@ public class OKProgressions extends ModBase {
         putGenericReference(REFKEY_MOD_VERSION, Reference.VERSION);
 
         getRegistryManager().addRegistry(IRetroGenRegistry.class, new RetroGenRegistry(this));
-        putGenericReference(REFKEY_RETROGEN, true);
+        putGenericReference(REFKEY_RETROGEN, ModConfig.retrogenEnabled);
 
         addInitListeners(new SoilLoader());
         addInitListeners(new CropLoader());

--- a/src/main/java/ruiseki/okprogressions/config/ModConfig.java
+++ b/src/main/java/ruiseki/okprogressions/config/ModConfig.java
@@ -72,4 +72,8 @@ public class ModConfig {
     @Config.DefaultInt(750)
     @Config.RangeInt(min = 1)
     public static int particalTicks;
+
+    @Config.DefaultBoolean(true)
+    @Config.Comment("Enable retrogeneration of world features when the mod is added to an existing world")
+    public static boolean retrogenEnabled;
 }


### PR DESCRIPTION
Config Option for the retrogeneration of world features (currently just enderOre from okprogression)